### PR TITLE
Write albums in nested folders

### DIFF
--- a/bin/thumbsup.js
+++ b/bin/thumbsup.js
@@ -35,8 +35,8 @@ var opts = yargs
     // ------------------------------------
 
     'index': {
-      description: 'Filename of the home page, without extension',
-      default: 'index'
+      description: 'Filename of the home page',
+      default: 'index.html'
     },
     'title': {
       description: 'Website title',

--- a/src/model/album.js
+++ b/src/model/album.js
@@ -1,4 +1,5 @@
 var _ = require('lodash');
+var path = require('path');
 var index = 0;
 
 // number of images to show in the album preview grid
@@ -25,9 +26,13 @@ function Album(opts) {
   if (typeof opts === 'string') opts = { title: opts };
   this.id = opts.id || ++index;
   this.title = opts.title || ('Album ' + this.id);
-  this.filename = sanitise(this.title);
+  // target folder/filename on disk
+  this.filename = 'index.html';
+  this.folder = sanitise(this.title);
+  // photos, videos and nested albums
   this.files = opts.files || [];
   this.albums = opts.albums || [];
+  // some stats
   this.depth = 0;
   this.home = false;
   this.stats = null;
@@ -42,7 +47,8 @@ Album.prototype.finalize = function(options) {
   // finalize all nested albums first (recursive)
   // and set a nested filename
   for (var i = 0; i < this.albums.length; ++i) {
-    this.albums[i].filename = this.filename + '-' + this.albums[i].filename;
+    var prefix = this.home ? 'albums' : this.folder;
+    this.albums[i].folder = path.join(prefix, this.albums[i].folder);
     this.albums[i].depth = this.depth + 1;
     this.albums[i].finalize();
   }
@@ -115,7 +121,7 @@ Album.prototype.aggregateAllFiles = function() {
 };
 
 function sanitise(filename) {
-  return filename.replace(/[^a-z0-9-_]/ig, '');
+  return filename.replace(/[^a-z0-9-_]/ig, '-');
 }
 
 function itemCount(count, type) {

--- a/src/model/hierarchy.js
+++ b/src/model/hierarchy.js
@@ -10,7 +10,8 @@ exports.createAlbums = function(collection, opts) {
 
   // top-level album for the home page
   var home = new Album('Home');
-  home.filename = opts.index || 'index';
+  home.folder = '';
+  home.filename = opts.index || 'index.html';
 
   // create albums
   if (opts.albumsFrom === 'folders') {
@@ -22,6 +23,6 @@ exports.createAlbums = function(collection, opts) {
   }
 
   // finalize all albums recursively (calculate stats, etc...)
-  home.finalize();
+  home.finalize(opts);
   return home;
 };

--- a/src/output-website/template.js
+++ b/src/output-website/template.js
@@ -8,6 +8,9 @@ exports.create = function(options) {
   var DIR_TEMPLATES = path.join(__dirname, '..', '..', 'templates');
   var DIR_THEME = path.join(DIR_TEMPLATES, 'themes', options.theme);
 
+  // used for rendering relative paths
+  var currentFolder = '';
+
   function isTemplate(filepath) {
     return path.extname(filepath) === '.hbs';
   }
@@ -76,14 +79,14 @@ exports.create = function(options) {
         operator = "===";
       }
       operators = {
-        '==': function (l, r) { return l == r; },
+        '==':  function (l, r) { return l == r;  },
         '===': function (l, r) { return l === r; },
-        '!=': function (l, r) { return l != r; },
+        '!=':  function (l, r) { return l != r;  },
         '!==': function (l, r) { return l !== r; },
-        '<': function (l, r) { return l < r; },
-        '>': function (l, r) { return l > r; },
-        '<=': function (l, r) { return l <= r; },
-        '>=': function (l, r) { return l >= r; }
+        '<':   function (l, r) { return l < r;   },
+        '>':   function (l, r) { return l > r;   },
+        '<=':  function (l, r) { return l <= r;  },
+        '>=':  function (l, r) { return l >= r;  }
       };
       if (!operators[operator]) {
         throw new Error("Handlerbars Helper 'compare' doesn't know the operator " + operator);
@@ -106,8 +109,15 @@ exports.create = function(options) {
     }
   });
 
+  // utility helper
+  // return the relative path from the current folder to the argument
+  handlebars.registerHelper('relative', function(target) {
+    return path.relative(currentFolder, target);
+  });
+
   return {
-    render: function(template, data) {
+    render: function(template, data, targetDir) {
+      currentFolder = targetDir;
       return templates[template](data);
     }
   };

--- a/src/output-website/template.js
+++ b/src/output-website/template.js
@@ -102,6 +102,7 @@ exports.create = function(options) {
   // utility helper
   // render the correct download path based on user options
   handlebars.registerHelper('download', function(file) {
+    // var rel = path.relative(currentFolder, target);
     if (file.mediaType === 'video') {
       return options.originalVideos ? file.urls.original : file.urls.video;
     } else {

--- a/src/output-website/website.js
+++ b/src/output-website/website.js
@@ -36,7 +36,7 @@ exports.build = function(rootAlbum, opts, callback) {
 
   function renderAlbum(gallery, breadcrumbs, album) {
     // render this album
-    var thisAlbumTask = renderTemplate(album.filename + '.html', 'album', {
+    var thisAlbumTask = renderTemplate(path.join(album.folder, album.filename), 'album', {
       gallery: gallery,
       breadcrumbs: breadcrumbs,
       album: album
@@ -52,9 +52,11 @@ exports.build = function(rootAlbum, opts, callback) {
 
   function renderTemplate(filename, templateName, data) {
     // render a given HBS template
+    var baseDir = path.dirname(filename);
     var fullPath = path.join(opts.output, filename);
-    var contents = renderer.render(templateName, data);
     return function(next) {
+      var contents = renderer.render(templateName, data, baseDir);
+      fs.mkdirsSync(path.dirname(fullPath));
       fs.writeFile(fullPath, contents, next);
     };
   }

--- a/templates/album.hbs
+++ b/templates/album.hbs
@@ -5,12 +5,12 @@
       <meta charset="utf-8" />
       <meta name="viewport" content="width=device-width, user-scalable=no" />
       <title>{{gallery.title}} - {{album.title}}</title>
-      <link rel="stylesheet" href="public/reset.css" />
-      <link rel="stylesheet" href="public/style.css" />
-      <link rel="stylesheet" href="public/viewer.css" />
-      <link rel="stylesheet" href="public/font-awesome/css/font-awesome.min.css">
-      <link rel="stylesheet" href="public/light-gallery/css/lightgallery.css" />
-      <link rel="stylesheet" href="public/video-js.css" />
+      <link rel="stylesheet" href="{{relative 'public/reset.css'}}" />
+      <link rel="stylesheet" href="{{relative 'public/style.css'}}" />
+      <link rel="stylesheet" href="{{relative 'public/viewer.css'}}" />
+      <link rel="stylesheet" href="{{relative 'public/font-awesome/css/font-awesome.min.css'}}">
+      <link rel="stylesheet" href="{{relative 'public/light-gallery/css/lightgallery.css'}}" />
+      <link rel="stylesheet" href="{{relative 'public/video-js.css'}}" />
   </head>
 
   <body>
@@ -23,7 +23,7 @@
         {{#if isVideo}}
           <div id="media{{id}}" style="display:none;">
             <video class="lg-video-object lg-html5 video-js vjs-default-skin"  preload="none" controls>
-              <source src="{{urls.video}}" type="video/mp4" />
+              <source src="{{relative urls.video}}" type="video/mp4" />
               Your browser does not support HTML5 video
             </video>
           </div>
@@ -32,15 +32,15 @@
     </div>
 
     <!-- jQuery -->
-    <script src="public/jquery.min.js"></script>
+    <script src="{{relative 'public/jquery.min.js'}}"></script>
     <!-- VideoJS -->
-    <script src="public/video.js"></script>
+    <script src="{{relative 'public/video.js'}}"></script>
     <!-- LightGallery -->
-    <script src="public/light-gallery/js/lightgallery.js"></script>
-    <script src="public/light-gallery/js/lg-autoplay.js"></script>
-    <script src="public/light-gallery/js/lg-pager.js"></script>
-    <script src="public/light-gallery/js/lg-thumbnail.js"></script>
-    <script src="public/light-gallery/js/lg-video.js"></script>
+    <script src="{{relative 'public/light-gallery/js/lightgallery.js'}}"></script>
+    <script src="{{relative 'public/light-gallery/js/lg-autoplay.js'}}"></script>
+    <script src="{{relative 'public/light-gallery/js/lg-pager.js'}}"></script>
+    <script src="{{relative 'public/light-gallery/js/lg-thumbnail.js'}}"></script>
+    <script src="{{relative 'public/light-gallery/js/lg-video.js'}}"></script>
 
     <script>
       $(document).ready(function() {

--- a/templates/themes/mosaic/theme.hbs
+++ b/templates/themes/mosaic/theme.hbs
@@ -14,10 +14,10 @@
   <nav class="breadcrumbs">
     <div class="mask"></div>
     {{#each breadcrumbs~}}
-      <a class="breadcrumb-item" href="{{filename}}.html">{{title}}</a>
+      <a class="breadcrumb-item" href="{{relative folder}}/{{filename}}">{{title}}</a>
       <span class="separator">&gt;</span>
     {{~/each~}}
-    <a class="breadcrumb-item" href="{{album.filename}}.html">{{album.title}}</a>
+    <a class="breadcrumb-item" href="{{album.filename}}">{{album.title}}</a>
   </nav>
 
   <!--
@@ -31,7 +31,7 @@
     <ul id="albums">
       {{#each album.albums~}}
       <li>
-        <a href="{{filename}}.html">
+        <a href="{{relative folder}}/{{filename}}">
           <h3>{{title}}</h3>
           <div class="meta">
             <time>{{{date stats.fromDate}}} - {{{date stats.toDate}}}</time><span class="separator">,</span>
@@ -39,7 +39,7 @@
           </div>
           <ul class="grid clearfix">
             {{~#slice previews count=8~}}
-              <li><img src="{{this.urls.thumb}}" /></li>
+              <li><img src="{{relative this.urls.thumb}}" /></li>
             {{~/slice}}
           </ul>
         </a>
@@ -57,7 +57,7 @@
               data-poster="{{urls.poster}}"
               data-download-url="{{{download this}}}">
             <a href="{{{download this}}}">
-              <img src="{{urls.thumb}}"
+              <img src="{{relative urls.thumb}}"
                    width="{{@root.gallery.thumbSize}}"
                    height="{{@root.gallery.thumbSize}}"
                    alt="{{filename}}" />
@@ -65,11 +65,11 @@
             <img class="video-overlay" src="public/play.png" />
           </li>
         {{else}}
-          <li data-src="{{urls.large}}"
+          <li data-src="{{relative urls.large}}"
               data-sub-html="{{caption}}"
               data-download-url="{{{download this}}}">
             <a href="{{{download this}}}">
-              <img src="{{urls.thumb}}"
+              <img src="{{relative urls.thumb}}"
                    width="{{@root.gallery.thumbSize}}"
                    height="{{@root.gallery.thumbSize}}"
                    alt="{{filename}}" />


### PR DESCRIPTION
To keep things simple, all albums so far were at the root. To avoid clashes between nested album names, they had to be named based on their full ancestry, for example `{{grandparent}}-{{parent}}-{{title}}.html`. This can get a little awkward, for example:

```
.
|__ public
|__ media
|__ index.html
|__ 2016.html
|__ 2016-2016-10.html
|__ 2016-2016-10-2016-10-06.html
```

This tentative PR uses sub-folders instead to see if it's any better. For the example above, it generates:

```
.
|__ index.html
|__ public
|__ media
|__ albums
    |__ 2016
        |__ index.html
        |__ 2016-10
            |__ index.html
            |__ 2016-10-06
                |__ index.html
```

It makes it much easier to browse and play with locally. The tricky part becomes relative links, so this PR introduces a new handlebars helper:

```hbs
{{relative 'public/styles.css'}}
{{relative album.folder}}
{{relative media.urls.thumb}}
```

*Note:* If we introduce album previews later, they would simply go in the album's folder, e.g.

```
|__ albums
    |__ 2016
        |__ index.html
        |__ index.jpg
```
